### PR TITLE
Updated getRole function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const getRole = (rolename) => {
   rolename = rolename.toLowerCase()
   rolename = rolename.replace("-", " ")
   rolename = aliases[rolename] ? aliases[rolename] : rolename
-  let foundRole = roles.find((x) => x.name.toLowerCase() == rolename)
+  let foundRole = roles.find((x) => x.name.toLowerCase().startsWith(rolename))
   if (!foundRole) return { name: "Unknown Role", description: "Unable to find that role!", icon: "https://cdn.discordapp.com/emojis/424929422190182422.png?v=1" }
   return foundRole
 }


### PR DESCRIPTION
- Allows people to find a role without writing a specific alias or name
- Why? Some roles, such as zombie might not have an alias. With this function it searches the role that `starts with` instead of finding the exact role
- Aliases can still be used